### PR TITLE
Add take interview page and navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import Interviews from "./pages/interviews";
 import InterviewForm from "./pages/InterviewForm";
 import Questions from "./pages/Questions";
 import Applicants from "./pages/Applicants";
+import TakeInterview from "./pages/TakeInterview";
 import "./App.css";
 
 export default function App() {
@@ -13,6 +14,10 @@ export default function App() {
         <Route path="/interviews/new" element = {<InterviewForm />} />
         <Route path="/interviews/:id/questions" element = {<Questions />} />
         <Route path="interviews/:id/applicants" element = {<Applicants/>}/>
+        <Route
+          path="interviews/:id/applicants/:applicantId/interview"
+          element={<TakeInterview />}
+        />
       </Routes>
     </Router>
   );

--- a/src/data/applicants.js
+++ b/src/data/applicants.js
@@ -1,0 +1,16 @@
+export const APPLICANTS = [
+  {
+    id: "john-smith",
+    name: "Mr John Smith",
+    email: "john@email.com",
+    phone: "555-0123",
+    status: "Completed",
+  },
+  {
+    id: "sarah-johnson",
+    name: "Ms Sarah Johnson",
+    email: "sarah@email.com",
+    phone: "555-0456",
+    status: "Not Started",
+  },
+];

--- a/src/pages/Applicants.jsx
+++ b/src/pages/Applicants.jsx
@@ -1,21 +1,7 @@
 import React from "react";
 import { Link, useLocation, useParams } from "react-router-dom";
 import "./Interviews.css";
-
-const applicants = [
-  {
-    name: "Mr John Smith",
-    email: "john@email.com",
-    phone: "555-0123",
-    status: "Completed",
-  },
-  {
-    name: "Ms Sarah Johnson",
-    email: "sarah@email.com",
-    phone: "555-0456",
-    status: "Not Started",
-  },
-];
+import { APPLICANTS } from "../data/applicants";
 
 const statusClassMap = {
   Completed: "status-tag status-tag--completed",
@@ -23,7 +9,7 @@ const statusClassMap = {
 };
 
 export default function Applicants() {
-  const { id } = useParams();
+  const { id: interviewId } = useParams();
   const { state } = useLocation();
   const interviewTitle = state?.interviewTitle || "Untitled Interview";
 
@@ -68,7 +54,7 @@ export default function Applicants() {
                   </tr>
                 </thead>
                 <tbody>
-                  {applicants.map((applicant) => (
+                  {APPLICANTS.map((applicant) => (
                     <tr key={applicant.email}>
                       <td>{applicant.name}</td>
                       <td>{applicant.email}</td>
@@ -84,9 +70,13 @@ export default function Applicants() {
                           <button type="button" className="rect-button rect-button--ghost">
                             Copy Link
                           </button>
-                          <button type="button" className="rect-button rect-button--outline">
+                          <Link
+                            to={`/interviews/${interviewId}/applicants/${applicant.id}/interview`}
+                            state={{ interviewTitle, applicant }}
+                            className="rect-button rect-button--outline"
+                          >
                             Take Interview
-                          </button>
+                          </Link>
                         </div>
                       </td>
                     </tr>

--- a/src/pages/TakeInterview.jsx
+++ b/src/pages/TakeInterview.jsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { Link, useLocation, useParams } from "react-router-dom";
+import "./Interviews.css";
+import { APPLICANTS } from "../data/applicants";
+
+export default function TakeInterview() {
+  const { state } = useLocation();
+  const { id: interviewId, applicantId } = useParams();
+  const interviewTitle = state?.interviewTitle || "Untitled Interview";
+  const applicantFromState = state?.applicant;
+  const applicantDetails =
+    applicantFromState || APPLICANTS.find((applicant) => applicant.id === applicantId);
+
+  if (!applicantDetails) {
+    return (
+      <div className="page-layout">
+        <header className="header">
+          <div className="header__left">
+            <Link to="/" className="header__action">
+              Interviews
+            </Link>
+          </div>
+          <h1 className="header__title">ReadySetHire - AI-Powered Interview Platform</h1>
+        </header>
+        <main className="main">
+          <div className="content">
+            <div className="card">
+              <h2 className="card__title">Applicant not found</h2>
+              <p>The applicant you are looking for could not be located.</p>
+              <Link to={`/interviews/${interviewId}/applicants`} className="rect-button rect-button--primary">
+                Back to Applicants
+              </Link>
+            </div>
+          </div>
+        </main>
+        <footer className="footer">
+          © 2025 ReadySetHire - Streamlining the hiring process with AI
+        </footer>
+      </div>
+    );
+  }
+
+  return (
+    <div className="page-layout">
+      <header className="header header--brand-left">
+        <h1 className="header__title header__title--left">
+          ReadySetHire - AI-Powered Interview Platform
+        </h1>
+        <div className="header__left">
+          <Link to="/" className="header__action">
+            Interviews
+          </Link>
+        </div>
+      </header>
+
+      <main className="main">
+        <div className="content content--narrow">
+          <div className="back-link-container">
+            <Link to={`/interviews/${interviewId}/applicants`} className="back-link">
+              ← Back to Applicants
+            </Link>
+          </div>
+
+          <section className="card card--centered">
+            <div className="card__body">
+              <h2 className="card__title">Welcome to Your Interview</h2>
+              <div className="take-interview__details">
+                <div className="take-interview__section">
+                  <h3 className="take-interview__heading">Applicant Details:</h3>
+                  <p>{applicantDetails.name}</p>
+                  <p>{applicantDetails.email}</p>
+                </div>
+                <div className="take-interview__section">
+                  <h3 className="take-interview__heading">Interview:</h3>
+                  <p>{interviewTitle}</p>
+                  <p>Interview for {interviewTitle} position</p>
+                </div>
+              </div>
+              <button type="button" className="rect-button rect-button--primary take-interview__button">
+                Start Interview
+              </button>
+            </div>
+          </section>
+        </div>
+      </main>
+
+      <footer className="footer">
+        © 2025 ReadySetHire - Streamlining the hiring process with AI
+      </footer>
+    </div>
+  );
+}

--- a/src/pages/interviews.css
+++ b/src/pages/interviews.css
@@ -79,6 +79,20 @@
   overflow: visible;
 }
 
+.card--centered {
+  display: flex;
+  justify-content: center;
+}
+
+.card__body {
+  padding: 40px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  align-items: center;
+  text-align: center;
+}
+
 .card__header {
   display: flex;
   justify-content: space-between;
@@ -136,6 +150,34 @@
 
 .back-link:hover {
   text-decoration: underline;
+}
+
+.take-interview__details {
+  width: 100%;
+  background-color: #f8faff;
+  border: 1px solid #e5eaf4;
+  padding: 24px 28px;
+  display: grid;
+  gap: 20px;
+}
+
+.take-interview__section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: #1f2933;
+}
+
+.take-interview__heading {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #111827;
+}
+
+.take-interview__button {
+  padding: 12px 20px;
+  font-size: 1rem;
 }
 
 .form {


### PR DESCRIPTION
## Summary
- add a shared applicants dataset with identifiers to support routing
- link the applicants table to a new take interview screen and render applicant/interview details
- style the take interview layout and register the route in the app router

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce553829b88329b8980e1cada69306